### PR TITLE
Switch from SweetAlert to SweetAlert2

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "reselect": "^2.5.4",
     "semver": "^5.3.0",
     "snake-case": "^2.1.0",
-    "sweetalert": "^1.1.3",
+    "sweetalert2": "^7.0.9",
     "uuid": "^3.0.0",
     "validator": "^6.1.0",
     "vex-js": "^3.0.0"

--- a/src/app/components/project-detail/project-detail.jsx
+++ b/src/app/components/project-detail/project-detail.jsx
@@ -9,7 +9,7 @@ import getOperationType from "app/components/graphiql/utils/get-operation-type"
 import {DocExplorer} from 'graphiql/dist/components/DocExplorer';
 import {connect} from "react-redux"
 import {bindActionCreators} from "redux"
-import swal from "sweetalert"
+import swal from "sweetalert2"
 import get from "lodash/get"
 import {createSelector} from "reselect"
 import applyVariablesToHeaders from "app/utils/apply-variables-to-headers"

--- a/src/app/components/project-list/project-list.jsx
+++ b/src/app/components/project-list/project-list.jsx
@@ -157,24 +157,16 @@ export default ({vex, actionCreators, selectors, factories, importExport, histor
             swal({
                 title: 'Add project',
                 text: "Choose a name for the project",
-                type: 'input',
+                input: 'text',
+                inputValidator: (value) => {
+                    return !value && 'You might want to fill in a name!'
+                },
                 showCancelButton: true,
-                closeOnConfirm: true,
                 animation: false
-            }, (value) => {
+            }).then((result) => {
+                const projectTitle = result.value
 
-                if (value === false) {
-                    return
-                }
-
-                if (!value || !value.length) {
-
-                    swal({
-                        title: "Error",
-                        text: "You might want to fill in a name!",
-                        type: "error",
-                        animation: false
-                    })
+                if (projectTitle === undefined) {
                     return
                 }
 
@@ -189,7 +181,7 @@ export default ({vex, actionCreators, selectors, factories, importExport, histor
                 this.props.projectsCreate({
                     id: project.get('id'),
                     data: project.merge({
-                        title: value,
+                        title: projectTitle,
                         activeEnvironmentId: environment.get('id'),
                         environmentIds: List([
                             environment.get('id')

--- a/src/app/components/project-panel/project-panel.jsx
+++ b/src/app/components/project-panel/project-panel.jsx
@@ -1,6 +1,6 @@
 import React from "react"
 import {Alert, Modal, FormGroup, FormControl, ControlLabel} from "react-bootstrap"
-import swal from "sweetalert"
+import swal from "sweetalert2"
 import {connect} from "react-redux"
 import {bindActionCreators} from "redux"
 
@@ -157,29 +157,21 @@ export default ({factories, actionCreators, selectors, MapEditor, Panel, PanelHe
             swal({
                 title: 'Add environment',
                 text: "Choose a name for the environment",
-                type: 'input',
+                input: 'text',
+                inputValidator: (value) => {
+                    return !value && 'You might want to fill in a name!'
+                },
                 showCancelButton: true,
-                closeOnConfirm: true,
                 animation: false
-            }, (value) => {
+            }).then((result) => {
+                const envTitle = result.value
 
-                if (value === false) {
-                    return
-                }
-
-                if (!value || !value.length) {
-
-                    swal({
-                        title: "Error",
-                        text: "You might want to fill in a name!",
-                        type: "error",
-                        animation: false
-                    })
+                if (envTitle === undefined) {
                     return
                 }
 
                 const environment = factories.createEnvironment().merge({
-                    title: value
+                    title: envTitle
                 })
 
                 this.props.environmentsCreate({

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,8 +8,7 @@ var options = {
             'babel-polyfill',
             'react',
             'react-dom',
-            'react-router',
-            'sweetalert/dist/sweetalert.css'
+            'react-router'
         ],
         app: './src/index.jsx'
     },


### PR DESCRIPTION
I would like to propose to switch from SweetAlert to [SweetAlert2](https://github.com/sweetalert2/sweetalert2) - the supported fork of SweetAlert. The original reason for creating SweetAlert2 is inactivity of SweetAlert: https://stackoverflow.com/a/27842854/1331425 

### Reasons to switch:

1. Accessibility (WAI-ARIA) - SweetAlert2 is fully WAI-ARIA compatible and supports all popular screen-readers. Accessibility is a must in 2017, there are a lot of explanatory and tech articles, but this one is truly inspirable: [Software development 450 words per minute](https://www.vincit.fi/en/blog/software-development-450-words-per-minute/)

2. Better buttons contrast is a huge advantage for all users especially for users with vision disabilities. 

3. Better support, average time to resolve an issue:

   - SweetAlert: ![](http://isitmaintained.com/badge/resolution/t4t5/sweetalert.svg)
   - SweetAlert2: ![](http://isitmaintained.com/badge/resolution/sweetalert2/sweetalert2.svg)

4. Better UX with input validation by using `inputValidator` 

5. SweetAlert2 is more popular that SweetAlert:

   - SweetAlert: ![](https://img.shields.io/npm/dm/sweetalert.svg)
   - SweetAlert2: ![](https://img.shields.io/npm/dm/sweetalert2.svg)
  